### PR TITLE
feat: support debug ic10 mod

### DIFF
--- a/stationeers_save_editor/schema.py
+++ b/stationeers_save_editor/schema.py
@@ -19425,6 +19425,31 @@ class DeviceInputOutputImportSaveData(DeviceAtmosphericSaveData):
 
 
 @dataclass
+class DebugMotherboardSaveData(MotherboardSaveData):
+    selected_holder_index: Optional[int] = field(
+        default=0,
+        metadata={
+            "name": "SelectedHolderIndex",
+            "type": "Element",
+        },
+    )
+    stepping_enabled: Optional[bool] = field(
+        default=False,
+        metadata={
+            "name": "SteppingEnabled",
+            "type": "Element",
+        },
+    )
+    debug_mode_enabled: Optional[bool] = field(
+        default=False,
+        metadata={
+            "name": "DebugModeEnabled",
+            "type": "Element",
+        },
+    )
+
+
+@dataclass
 class DiscoverSiteData(SpaceMapNodeActionData):
     site: list[SpaceMapNodeData] = field(
         default_factory=list,


### PR DESCRIPTION
seems like schema may be generated so let me know if there is a better way to do this...
adding support for debug ic10 modded saves.
maybe this opens a can of worms for mod support in general, but for now this is just a quick fix.
another alternative would be to ignore errors when parsing the XML file but that seems worse.

fix for:
```
Uncaught (in promise) PythonError: Traceback (most recent call last):
  File "/lib/python311.zip/_pyodide/_base.py", line 499, in eval_code
    .run(globals, locals)
     ^^^^^^^^^^^^^^^^^^^^
  File "/lib/python311.zip/_pyodide/_base.py", line 340, in run
    coroutine = eval(self.code, globals, locals)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<exec>", line 3, in <module>
  File "/home/pyodide/stationeers_save_editor/save_data.py", line 33, in __init__
    self.data = parser.from_string(data.decode("utf-8"), WorldData)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/mixins.py", line 67, in from_string
    return self.from_bytes(source.encode(), clazz, ns_map)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/mixins.py", line 88, in from_bytes
    return self.parse(io.BytesIO(source), clazz, ns_map)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/bases.py", line 58, in parse
    result = handler.parse(source, ns_map)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/handlers/native.py", line 45, in parse
    return self.process_context(ctx, ns_map)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/handlers/native.py", line 62, in process_context
    self.parser.start(
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/bases.py", line 94, in start
    child = item.child(qname, attrs, ns_map, len(objects))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/xsdata/formats/dataclass/parsers/nodes/element.py", line 467, in child
    raise ParserError(f"Unknown property {self.meta.qname}:{qname}")
xsdata.exceptions.ParserError: Unknown property ThingSaveData:ParentReferenceId

    at new_error (pyodide.asm.js:9:12519)
    at pyodide.asm.wasm:0x158827
    at pyodide.asm.wasm:0x15892c
    at Module._pythonexc2js (pyodide.asm.js:9:640895)
    at Module.callPyObjectKwargs (pyodide.asm.js:9:81856)
    at Proxy.callKwargs (pyodide.asm.js:9:97507)
    at Object.runPython (pyodide.asm.js:9:118859)
    at FileUploader.handleFile (stationeers-save-editor/:218:19)
```

problematic xml snippet:

```xml
    <ThingSaveData xsi:type="DebugMotherboardSaveData">
          <ReferenceId>31968</ReferenceId>
            <PrefabName>MotherboardDebugAnalyzer</PrefabName>
            <CustomName />
            <WorldPosition>
              <x>710.0005</x>
                <y>202.873779</y>
                <z>665.002747</z>
              </WorldPosition>
            <WorldRotation>
              <x>0.6532818</x>
              <y>0.6532812</y>
              <z>-0.2705974</z>
              <w>0.270598769</w>
                <eulerAngles>
                  <x>45.0000153</x>
                  <y>179.999878</y>
                  <z>90</z>
                </eulerAngles>
              </WorldRotation>
            <States />
            <IsCustomName>false</IsCustomName>
            <CustomColorIndex>-1</CustomColorIndex>
            <OwnerSteamId>0</OwnerSteamId>
            <Reagents />
            <Indestructable>false</Indestructable>
            <DamageState>
              <Brute>0</Brute>
                <Burn>0.4697</Burn>
                <Oxygen>0</Oxygen>
                <Hydration>0</Hydration>
                <Starvation>0</Starvation>
                <Toxic>0</Toxic>
                <Radiation>0</Radiation>
                <Stun>0</Stun>
                <Decay>0</Decay>
              </DamageState>
            <ParentReferenceId>11024</ParentReferenceId>
            <ParentSlotId>17</ParentSlotId>
            <Dragged>false</Dragged>
            <DragOffset>
              <x>0</x>
              <y>0</y>
              <z>0</z>
            </DragOffset>
            <Velocity>
              <x>0</x>
              <y>0</y>
              <z>0</z>
            </Velocity>
            <AngularVelocity>
              <x>0</x>
              <y>0</y>
              <z>0</z>
            </AngularVelocity>
            <HealthCurrent>0</HealthCurrent>
            <LinkedDeviceReferences />
            <Flag>0</Flag>
            <MasterMotherboard>0</MasterMotherboard>
            <SelectedHolderIndex>-1</SelectedHolderIndex>
            <SteppingEnabled>false</SteppingEnabled>
            <DebugModeEnabled>false</DebugModeEnabled>
          </ThingSaveData>
```


